### PR TITLE
Add a Dockerfile and `opam` metadata for convenient packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ocaml/opam:alpine
+COPY . /home/opam/src
+RUN sudo chown -R opam /home/opam/src
+WORKDIR /home/opam/src
+RUN opam pin add -n motto /home/opam/src
+RUN opam depext -uy --noninteractive motto
+RUN opam install -j 2 -v -y motto
+VOLUME /src
+WORKDIR /src
+ENTRYPOINT ["opam","config","exec","--","motto"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ If compilation fails, check that you have all dependencies listed in the
 Try running `./motto.byte -h` to see if you have a binary. See the section on
 "Testing" for how to run the tool over regression tests.
 
+## Using Docker
+
+If you have [Docker](http://docker.com) installed, you can also use a container
+to run the compiler without installing all the dependencies.  The source code
+can be mounted in `/src` within the container.
+
+```
+$ docker build -t motto .
+$ docker run -v `pwd`/tests:/src motto -q --parser_test_file flick_code/types_process.cp
+```
 
 # Getting going
 We start with the mathematical cousin of "Hello, world" -- i.e., the factorial

--- a/motto.install
+++ b/motto.install
@@ -1,0 +1,3 @@
+bin: [
+ "?_build/motto.byte" {"motto"}
+]

--- a/opam
+++ b/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+maintainer: "Nik Sultana"
+authors: [
+  "Richard G. Clegg"
+  "Masoud Koleini"
+  "Matteo Migliavacca"
+  "Nik Sultana"
+]
+homepage: "https://github.com/NaaS/motto"
+dev-repo: "https://github.com/NaaS/motto.git"
+bug-reports: "https://github.com/NaaS/motto/issues"
+license: "Apache2"
+build: ["./build.sh"]
+install: []
+remove: []
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "menhir"
+]
+available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
The `opam` metadata permits the system to be installed via the
[OPAM](https://opam.ocaml.org) source manager.  The Dockerfile
allows the installation of the compiler without having to install
all the dependencies locally.

```
docker run -v `pwd`/tests:/src motto -q --parser_test_file flick_code/types_process.cp
```

Signed-off-by: Anil Madhavapeddy anil@recoil.org
