### PR TITLE
Fix two dead links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,8 @@ To run the type checker on regression tests, see the
 
 # Background
 
-The Flick language implements the [crisp](https://github.com/NaaS/admin/wiki/crisp) language idea,
-but simplified as described in the
-[Flick](https://github.com/NaaS/system/tree/master/crisp/flick) description.
+The Flick language implements the crisplanguage idea, but simplified as described in the
+[Flick](https://github.com/NaaS/motto/blob/master/doc/crisp.md) description.
 
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ To run the type checker on regression tests, see the
 
 # Background
 
-The Flick language implements the crisplanguage idea, but simplified as described in the
-[Flick](https://github.com/NaaS/motto/blob/master/doc/crisp.md) description.
+The Flick language is a simplification of the [Crisp](https://github.com/NaaS/motto/blob/master/doc/crisp.md) language idea.
 
 
 # Dependencies


### PR DESCRIPTION
Remove the first and replace the second with a relevant, working URL.